### PR TITLE
Fixes to ctrl+click and middle-click behaviour of links in virtual content

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1740,6 +1740,9 @@ export default class VirtualFooterPlugin extends Plugin {
 	 * @param component The Obsidian Component associated with this content, for event registration.
 	 */
 	public attachInternalLinkHandlers(container: HTMLElement, sourcePath: string, component: Component): void {
+		// If in reading view, do nothing, as the default behavior is fine
+		if (container.closest(".markdown-reading-view")) return;
+
 		// Handle left-click on internal links and external file links
 		component.registerDomEvent(container, 'click', (event: MouseEvent) => {
 			if (event.button !== 0) return; // Only handle left-clicks

--- a/main.ts
+++ b/main.ts
@@ -1778,6 +1778,14 @@ export default class VirtualFooterPlugin extends Plugin {
 				if (href) {
 					this.app.workspace.openLinkText(href, sourcePath, true); // Always open in new pane for middle-click
 				}
+				return;
+			}
+
+			// Handle external file links which don't work natively in Live Preview injected content
+			const externalLink = target.closest('a.external-link') as HTMLAnchorElement;
+			if (externalLink && externalLink.href.startsWith('file:')) {
+				event.preventDefault();
+				window.open(externalLink.href);
 			}
 		});
 	}


### PR DESCRIPTION
This PR addresses https://github.com/Signynt/virtual-content/issues/53.

Two changes:

- Prevent links from being opened twice in two new tabs when they are middle-clicked or ctrl+clicked from reading view.
- Copy an existing fix for ctrl-click of external file links to also work when middle-clicking. This makes external file links consistent with Obsidian's default behaviour in both live preview and reading view.

I have not tested this PR, as I don't know how the build pipeline works. I have only tested by modifying files of the already installed plugin, which are processed JS files and not the source TS files.