### PR TITLE
feature: Allow for [[#]]/[[]] in dataview queries.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -2722,7 +2722,7 @@ export default class VirtualFooterPlugin extends Plugin {
 			}
 			
 			// Execute the query against the active file
-			const results = await dataviewApi.query(query);
+			const results = await dataviewApi.query(query, file.path);
 
 			// Dataview API returns a Success object with a 'successful' flag and 'value' property
 			if (!results || !results.successful || !results.value || !Array.isArray(results.value.values)) {


### PR DESCRIPTION
Solves #63. 

Pass `file.path` to `dv.query` in `_checkDataviewMatch` in order to get dataview to correctly expand `[[#]]`/`[[]]` to the file we're testing.